### PR TITLE
Fix Elements Hash

### DIFF
--- a/bitcoin/block.c
+++ b/bitcoin/block.c
@@ -4,6 +4,8 @@
 #include "bitcoin/groestl.h"
 #include <ccan/str/hex/hex.h>
 #include <common/type_to_string.h>
+#include <common/status.h>
+#include <stdio.h>
 
 /* Encoding is <blockhdr> <varint-num-txs> <tx>... */
 struct bitcoin_block *
@@ -100,11 +102,17 @@ void bitcoin_block_blkid(const struct bitcoin_block *b,
 	u8 vt[VARINT_MAX_LEN];
 	size_t vtlen;
 
+	//fprintf(stderr, "bitcoin_block_blkid - start[%lx, %lx]\n", (long)b, (long)out);
 	groestl512_init(&shactx);
+	//fprintf(stderr, "bitcoin_block_blkid - init\n");
 	groestl512_le32(&shactx, b->hdr.version);
+	//fprintf(stderr, "bitcoin_block_blkid - processing version [%lu]\n", (long)b->hdr.version);
 	groestl512_update(&shactx, &b->hdr.prev_hash, sizeof(b->hdr.prev_hash));
 	groestl512_update(&shactx, &b->hdr.merkle_hash, sizeof(b->hdr.merkle_hash));
+	//fprintf(stderr, "bitcoin_block_blkid - processing hashes\n");
 	groestl512_le32(&shactx, b->hdr.timestamp);
+	//fprintf(stderr, "bitcoin_block_blkid - processing timestamp [%lu]\n", (long)b->hdr.timestamp);
+
 
     if (is_elements(chainparams)) {
 		size_t clen = tal_bytelen(b->elements_hdr->proof.challenge);

--- a/bitcoin/block.c
+++ b/bitcoin/block.c
@@ -89,7 +89,7 @@ void bitcoin_block_blkid(const struct bitcoin_block *b,
 		sha256_le32(&shactx, b->hdr.target);
 		sha256_le32(&shactx, b->hdr.nonce);
 	}
-	groestl512_double(&shactx, &out->shad);
+	groestl512_double(&shactx, &out->shad, sizeof(out->shad));
 }
 
 /* We do the same hex-reversing crud as txids. */

--- a/bitcoin/block.c
+++ b/bitcoin/block.c
@@ -4,8 +4,6 @@
 #include "bitcoin/groestl.h"
 #include <ccan/str/hex/hex.h>
 #include <common/type_to_string.h>
-#include <common/status.h>
-#include <stdio.h>
 
 /* Encoding is <blockhdr> <varint-num-txs> <tx>... */
 struct bitcoin_block *
@@ -102,17 +100,11 @@ void bitcoin_block_blkid(const struct bitcoin_block *b,
 	u8 vt[VARINT_MAX_LEN];
 	size_t vtlen;
 
-	//fprintf(stderr, "bitcoin_block_blkid - start[%lx, %lx]\n", (long)b, (long)out);
 	groestl512_init(&shactx);
-	//fprintf(stderr, "bitcoin_block_blkid - init\n");
 	groestl512_le32(&shactx, b->hdr.version);
-	//fprintf(stderr, "bitcoin_block_blkid - processing version [%lu]\n", (long)b->hdr.version);
 	groestl512_update(&shactx, &b->hdr.prev_hash, sizeof(b->hdr.prev_hash));
 	groestl512_update(&shactx, &b->hdr.merkle_hash, sizeof(b->hdr.merkle_hash));
-	//fprintf(stderr, "bitcoin_block_blkid - processing hashes\n");
 	groestl512_le32(&shactx, b->hdr.timestamp);
-	//fprintf(stderr, "bitcoin_block_blkid - processing timestamp [%lu]\n", (long)b->hdr.timestamp);
-
 
     if (is_elements(chainparams)) {
 		size_t clen = tal_bytelen(b->elements_hdr->proof.challenge);

--- a/bitcoin/block.c
+++ b/bitcoin/block.c
@@ -63,6 +63,35 @@ bitcoin_block_from_hex(const tal_t *ctx, const struct chainparams *chainparams,
 	return b;
 }
 
+void bitcoin_block_blkid(const struct bitcoin_block *b,
+			 struct bitcoin_blkid *out)
+{
+	struct sha256_ctx shactx;
+	u8 vt[VARINT_MAX_LEN];
+	size_t vtlen;
+
+	sha256_init(&shactx);
+	sha256_le32(&shactx, b->hdr.version);
+	sha256_update(&shactx, &b->hdr.prev_hash, sizeof(b->hdr.prev_hash));
+	sha256_update(&shactx, &b->hdr.merkle_hash, sizeof(b->hdr.merkle_hash));
+	sha256_le32(&shactx, b->hdr.timestamp);
+
+    if (is_elements(chainparams)) {
+		size_t clen = tal_bytelen(b->elements_hdr->proof.challenge);
+		sha256_le32(&shactx, b->elements_hdr->block_height);
+
+		vtlen = varint_put(vt, clen);
+		sha256_update(&shactx, vt, vtlen);
+		sha256_update(&shactx, b->elements_hdr->proof.challenge, clen);
+		/* The solution is skipped, since that'd create a circular
+		 * dependency apparently */
+	} else {
+		sha256_le32(&shactx, b->hdr.target);
+		sha256_le32(&shactx, b->hdr.nonce);
+	}
+	groestl512_double(&shactx, &out->shad);
+}
+
 /* We do the same hex-reversing crud as txids. */
 bool bitcoin_blkid_from_hex(const char *hexstr, size_t hexstr_len,
 			    struct bitcoin_blkid *blockid)

--- a/bitcoin/block.h
+++ b/bitcoin/block.h
@@ -2,6 +2,7 @@
 #define LIGHTNING_BITCOIN_BLOCK_H
 #include "config.h"
 #include "bitcoin/shadouble.h"
+#include "bitcoin/groestl.h"
 #include <ccan/endian/endian.h>
 #include <ccan/short_types/short_types.h>
 #include <ccan/structeq/structeq.h>
@@ -47,7 +48,11 @@ bitcoin_block_from_hex(const tal_t *ctx, const struct chainparams *chainparams,
 		       const char *hex, size_t hexlen);
 
 /* Compute the double SHA block ID from the block header. */
-void bitcoin_block_blkid(const struct bitcoin_block *block,
+void bitcoin_block_blkid_sha(const struct bitcoin_block *block,
+			 struct bitcoin_blkid *out);
+
+/* Compute the double Groestl512(256) block ID from the block header. */
+void bitcoin_block_blkid(const struct bitcoin_block *b,
 			 struct bitcoin_blkid *out);
 
 /* Parse hex string to get blockid (reversed, a-la groestlcoind). */

--- a/bitcoin/block.h
+++ b/bitcoin/block.h
@@ -46,6 +46,10 @@ struct bitcoin_block *
 bitcoin_block_from_hex(const tal_t *ctx, const struct chainparams *chainparams,
 		       const char *hex, size_t hexlen);
 
+/* Compute the double SHA block ID from the block header. */
+void bitcoin_block_blkid(const struct bitcoin_block *block,
+			 struct bitcoin_blkid *out);
+
 /* Parse hex string to get blockid (reversed, a-la groestlcoind). */
 bool bitcoin_blkid_from_hex(const char *hexstr, size_t hexstr_len,
 			    struct bitcoin_blkid *blockid);

--- a/bitcoin/groestl.c
+++ b/bitcoin/groestl.c
@@ -3,6 +3,7 @@
 #include <bitcoin/sph_types.h>
 #include <ccan/build_assert/build_assert.h>
 #include <ccan/tal/str/str.h>
+#include <ccan/endian/endian.h>
 #include <common/utils.h>
 #include <stdio.h>
 
@@ -42,6 +43,94 @@ void groestlhash(void *output, const void *input , size_t len)
 	};
 	printf ("\n");
 	*/
+}
+
+static void check_groestl512(sph_groestl512_context *ctx UNUSED)
+{
+//	assert(ctx->bytes != (size_t)-1);
+}
+
+void groestl512_init(sph_groestl512_context *ctx)
+{
+	sph_groestl512_init(&ctx);
+}
+
+void groestl512_update(sph_groestl512_context *ctx, const void *p, size_t size)
+{
+	check_groestl512(ctx);
+	sph_groestl512(&ctx, p, size);
+}
+
+void groestl512_done(sph_groestl512_context *ctx, struct groestl512 * res)
+{
+	sph_groestl512_close(ctx, res->u.u8);
+}
+
+void groestl512(struct groestl512 *sha, const void *p, size_t size)
+{
+	sph_groestl512_context ctx;
+
+	groestl512_init(&ctx);
+	groestl512_update(&ctx, p, size);
+	groestl512_done(&ctx, sha);
+}
+	
+void groestl512_u8(sph_groestl512_context *ctx, uint8_t v)
+{
+	groestl512_update(ctx, &v, sizeof(v));
+}
+
+void groestl512_u16(sph_groestl512_context *ctx, uint16_t v)
+{
+	groestl512_update(ctx, &v, sizeof(v));
+}
+
+void groestl512_u32(sph_groestl512_context *ctx, uint32_t v)
+{
+	groestl512_update(ctx, &v, sizeof(v));
+}
+
+void groestl512_u64(sph_groestl512_context *ctx, uint64_t v)
+{
+	groestl512_update(ctx, &v, sizeof(v));
+}
+
+/* Add as little-endian */
+void groestl512_le16(sph_groestl512_context *ctx, uint16_t v)
+{
+	leint16_t lev = cpu_to_le16(v);
+	groestl512_update(ctx, &lev, sizeof(lev));
+}
+	
+void groestl512_le32(sph_groestl512_context *ctx, uint32_t v)
+{
+	leint32_t lev = cpu_to_le32(v);
+	groestl512_update(ctx, &lev, sizeof(lev));
+}
+	
+void groestl512_le64(sph_groestl512_context *ctx, uint64_t v)
+{
+	leint64_t lev = cpu_to_le64(v);
+	groestl512_update(ctx, &lev, sizeof(lev));
+}
+
+/* Add as big-endian */
+void groestl512_be16(sph_groestl512_context *ctx, uint16_t v)
+{
+	beint16_t bev = cpu_to_be16(v);
+	groestl512_update(ctx, &bev, sizeof(bev));
+}
+	
+void groestl512_be32(sph_groestl512_context *ctx, uint32_t v)
+{
+	beint32_t bev = cpu_to_be32(v);
+	groestl512_update(ctx, &bev, sizeof(bev));
+}
+	
+void groestl512_be64(sph_groestl512_context *ctx, uint64_t v)
+{
+	beint64_t bev = cpu_to_be64(v);
+	groestl512_update(ctx, &bev, sizeof(bev));
 }
 
 

--- a/bitcoin/groestl.c
+++ b/bitcoin/groestl.c
@@ -52,13 +52,13 @@ static void check_groestl512(sph_groestl512_context *ctx UNUSED)
 
 void groestl512_init(sph_groestl512_context *ctx)
 {
-	sph_groestl512_init(&ctx);
+	sph_groestl512_init(ctx);
 }
 
 void groestl512_update(sph_groestl512_context *ctx, const void *p, size_t size)
 {
 	check_groestl512(ctx);
-	sph_groestl512(&ctx, p, size);
+	sph_groestl512(ctx, p, size);
 }
 
 void groestl512_done(sph_groestl512_context *ctx, struct groestl512 * res)

--- a/bitcoin/groestl.h
+++ b/bitcoin/groestl.h
@@ -4,6 +4,8 @@
 #include "bitcoin/sph_groestl.h"
 #include "bitcoin/shadouble.h"
 #include <sys/types.h>
+#include <common/type_to_string.h>
+
 
 void groestlhash(void *, const void * , size_t);
 
@@ -27,6 +29,9 @@ struct groestl256 {
 		unsigned char u8[32];
 	} u;
 };
+
+//REGISTER_TYPE_TO_STRING(groestl512, fmt_groestl512);
+
 
 /**
  * groestl512 - return groestl512 of an object.

--- a/bitcoin/groestl.h
+++ b/bitcoin/groestl.h
@@ -4,8 +4,6 @@
 #include "bitcoin/sph_groestl.h"
 #include "bitcoin/shadouble.h"
 #include <sys/types.h>
-#include <common/type_to_string.h>
-
 
 void groestlhash(void *, const void * , size_t);
 
@@ -29,9 +27,6 @@ struct groestl256 {
 		unsigned char u8[32];
 	} u;
 };
-
-//REGISTER_TYPE_TO_STRING(groestl512, fmt_groestl512);
-
 
 /**
  * groestl512 - return groestl512 of an object.

--- a/bitcoin/groestl.h
+++ b/bitcoin/groestl.h
@@ -1,7 +1,110 @@
 #ifndef LIGHTNING_BITCOIN_GROESTL_H
 #define LIGHTNING_BITCOIN_GROESTL_H
 #include "config.h"
+#include "bitcoin/sph_groestl.h"
+#include "bitcoin/shadouble.h"
 #include <sys/types.h>
 
 void groestlhash(void *, const void * , size_t);
+
+/**
+ * struct groestl512 - structure representing a completed groestl512.
+ * @u.u8: an unsigned char array.
+ * @u.u32: a 32-bit integer array.
+ *
+ * Other fields may be added to the union in future.
+ */
+struct groestl512 {
+	union {
+		uint32_t u32[16];
+		unsigned char u8[64];
+	} u;
+};
+
+struct groestl256 {
+	union {
+		uint32_t u32[8];
+		unsigned char u8[32];
+	} u;
+};
+
+/**
+ * groestl512 - return groestl512 of an object.
+ * @groestl512: the groestl512 to fill in
+ * @p: pointer to memory,
+ * @size: the number of bytes pointed to by @p
+ *
+ * The bytes pointed to by @p is groestl512 hashed into @groestl512.  This is
+ * equivalent to groestl512_init(), groestl512_update() then groestl512_done().
+ */
+void groestl512(struct groestl512 *sha, const void *p, size_t size);
+
+/**
+ * groestl512_init - initialize an groestl512 context.
+ * @ctx: the sph_groestl512_context to initialize
+ *
+ * This must be called before groestl512_update or groestl512_done, or
+ * alternately you can assign groestl512_INIT.
+ *
+ * If it was already initialized, this forgets anything which was
+ * hashed before.
+ *
+ * Example:
+ * static void hash_all(const char **arr, struct groestl512 *hash)
+ * {
+ *	size_t i;
+ *	struct sph_groestl512_context ctx;
+ *
+ *	groestl512_init(&ctx);
+ *	for (i = 0; arr[i]; i++)
+ *		groestl512_update(&ctx, arr[i], strlen(arr[i]));
+ *	groestl512_done(&ctx, hash);
+ * }
+ */
+void groestl512_init(sph_groestl512_context *ctx);
+
+/**
+ * groestl512_update - include some memory in the hash.
+ * @ctx: the sph_groestl512_context to use
+ * @p: pointer to memory,
+ * @size: the number of bytes pointed to by @p
+ *
+ * You can call this multiple times to hash more data, before calling
+ * groestl512_done().
+ */
+void groestl512_update(sph_groestl512_context *ctx, const void *p, size_t size);
+
+/**
+ * groestl512_done - finish groestl512 and return the hash
+ * @ctx: the sph_groestl512_context to complete
+ * @res: the hash to return.
+ *
+ * Note that @ctx is *destroyed* by this, and must be reinitialized.
+ * To avoid that, pass a copy instead.
+ */
+void groestl512_done(sph_groestl512_context *groestl512, struct groestl512 *res);
+
+/* Add various types to an groestl512 hash */
+void groestl512_u8(sph_groestl512_context *ctx, uint8_t v);
+void groestl512_u16(sph_groestl512_context *ctx, uint16_t v);
+void groestl512_u32(sph_groestl512_context *ctx, uint32_t v);
+void groestl512_u64(sph_groestl512_context *ctx, uint64_t v);
+
+/* Add as little-endian */
+void groestl512_le16(sph_groestl512_context *ctx, uint16_t v);
+void groestl512_le32(sph_groestl512_context *ctx, uint32_t v);
+void groestl512_le64(sph_groestl512_context *ctx, uint64_t v);
+
+/* Add as big-endian */
+void groestl512_be16(sph_groestl512_context *ctx, uint16_t v);
+void groestl512_be32(sph_groestl512_context *ctx, uint32_t v);
+void groestl512_be64(sph_groestl512_context *ctx, uint64_t v);
+
+struct groestl512_double256 {
+	struct groestl256 groestl;
+};
+
+void groestl512_double_done256(sph_groestl512_context *sha256, struct sha256_double *res);
+
+
 #endif /* LIGHTNING_BITCOIN_GROESTL_H */

--- a/bitcoin/shadouble.c
+++ b/bitcoin/shadouble.c
@@ -20,4 +20,14 @@ void groestl512_double(struct sha256_double *shadouble, const void *p, size_t le
 {
 	groestlhash((void *)&shadouble->sha, (void *)p, len);
 }
+
+void groestl512_double_done256(sph_groestl512_context *shactx, struct sha256_double *res)
+{
+	struct groestl512 result;
+	groestl512_done(shactx, &result);
+	struct groestl512 result2;
+	groestl512(&result2, &result, sizeof(result));
+	memcpy(&res->sha, &result2, sizeof(res));
+}
+
 REGISTER_TYPE_TO_HEXSTR(sha256_double);

--- a/bitcoin/shadouble.c
+++ b/bitcoin/shadouble.c
@@ -3,7 +3,6 @@
 #include <ccan/mem/mem.h>
 #include <common/type_to_string.h>
 #include <common/utils.h>
-#include <stdio.h>
 
 void sha256_double(struct sha256_double *shadouble, const void *p, size_t len)
 {
@@ -29,22 +28,7 @@ void groestl512_double_done256(sph_groestl512_context *shactx, struct sha256_dou
 	struct groestl512 result2;
 	groestl512(&result2, &result, sizeof(result));
 	memcpy(res, &result2, 32);
-
-/*	fprintf(stderr, "groestl512_double_done256 - double hash: ");
-	int ii;
-	for (ii=0; ii < 64; ii++)
-	{
-		fprintf(stderr,"%.2x",((uint8_t*)&result2)[ii]);
-	};
-	fprintf(stderr,"---\ngroestl512_double_done256 - double hash (32)");
-	for (ii=0; ii < 32; ii++)
-	{
-		fprintf(stderr,"%.2x",((uint8_t*)res)[ii]);
-	};
-	fprintf(stderr,"\n");
-*/
 }
 
 REGISTER_TYPE_TO_HEXSTR(sha256_double);
-//REGISTER_TYPE_TO_HEXSTR(groestl512);
 

--- a/bitcoin/shadouble.c
+++ b/bitcoin/shadouble.c
@@ -3,6 +3,7 @@
 #include <ccan/mem/mem.h>
 #include <common/type_to_string.h>
 #include <common/utils.h>
+#include <stdio.h>
 
 void sha256_double(struct sha256_double *shadouble, const void *p, size_t len)
 {
@@ -27,7 +28,23 @@ void groestl512_double_done256(sph_groestl512_context *shactx, struct sha256_dou
 	groestl512_done(shactx, &result);
 	struct groestl512 result2;
 	groestl512(&result2, &result, sizeof(result));
-	memcpy(&res->sha, &result2, sizeof(res));
+	memcpy(res, &result2, 32);
+
+/*	fprintf(stderr, "groestl512_double_done256 - double hash: ");
+	int ii;
+	for (ii=0; ii < 64; ii++)
+	{
+		fprintf(stderr,"%.2x",((uint8_t*)&result2)[ii]);
+	};
+	fprintf(stderr,"---\ngroestl512_double_done256 - double hash (32)");
+	for (ii=0; ii < 32; ii++)
+	{
+		fprintf(stderr,"%.2x",((uint8_t*)res)[ii]);
+	};
+	fprintf(stderr,"\n");
+*/
 }
 
 REGISTER_TYPE_TO_HEXSTR(sha256_double);
+//REGISTER_TYPE_TO_HEXSTR(groestl512);
+

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -693,7 +693,7 @@ static struct block *new_block(struct chain_topology *topo,
 {
 	struct block *b = tal(topo, struct block);
 
-	groestl512_double(&b->blkid.shad, &blk->hdr, sizeof(blk->hdr));
+	bitcoin_block_blkid(blk, &b->blkid);
 	log_debug(topo->log, "Adding block %u: %s",
 		  height,
 		  type_to_string(tmpctx, struct bitcoin_blkid, &b->blkid));


### PR DESCRIPTION
This will return the block hash to the upstream version that supports elements while using groestl hash instead of sha256d.